### PR TITLE
Optimize HttpClient usage in MultiTenantOptions to use a single static instance

### DIFF
--- a/src/Mellon.MultiTenant.Base/MultiTenantOptions.cs
+++ b/src/Mellon.MultiTenant.Base/MultiTenantOptions.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.Configuration;
 
 public class MultiTenantOptions
 {
+	private static readonly Lazy<HttpClient> _httpClientLazy = new(() => new HttpClient(), LazyThreadSafetyMode.ExecutionAndPublication);
+
 	public TenantSource TenantSource { get; set; } = TenantSource.Settings;
 
 	public string ApplicationName { get; set; }
@@ -67,9 +69,7 @@ public class MultiTenantOptions
 				request.Headers.Add("Authorization", endpointOptions.Authorization);
 			}
 
-			using var client = new HttpClient();
-
-			var result = await client.SendAsync(request);
+			var result = await _httpClientLazy.Value.SendAsync(request);
 
 			if (result.IsSuccessStatusCode)
 			{


### PR DESCRIPTION
This pull request resolves https://github.com/Pub-Dev/Mellon.MultiTenant/issues/32.

I decided to go with the simpler static `HttpClient` instance rather than `IHttpClientFactory` as the latter requires an additional dependency injection. Since `HttpClient` is only likely to get used a few times, I think this is acceptable.